### PR TITLE
Add Docker support for FastAPI and Frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Use the official Python image as a base image for the backend
+FROM python:3.11-slim AS backend
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install the dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code into the container
+COPY . .
+
+# Use the official Node.js image as a base image for the frontend
+FROM node:18 AS frontend
+
+# Set the working directory in the container
+WORKDIR /frontend
+
+# Copy the package.json and package-lock.json files into the container
+COPY frontend/package.json frontend/package-lock.json ./
+
+# Install the dependencies
+RUN npm install
+
+# Copy the rest of the frontend code into the container
+COPY frontend .
+
+# Build the frontend
+RUN npm run build
+
+# Use the official Python image as a base image for the final image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the backend and frontend build artifacts into the final image
+COPY --from=backend /app /app
+COPY --from=frontend /frontend/dist /app/frontend/dist
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Command to run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=sqlite:///./scytalio.db
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - VITE_API_BASE_URL=http://localhost:8000


### PR DESCRIPTION
Add Dockerfile and docker-compose.yml for FastAPI and Frontend.

* **Dockerfile**
  - Create a multi-stage build for backend and frontend.
  - Use Python 3.11-slim as the base image for the backend.
  - Use Node.js 18 as the base image for the frontend.
  - Install dependencies and build the frontend.
  - Expose port 8000 for the application.
  - Set the command to run the application using `uvicorn`.

* **docker-compose.yml**
  - Define services for backend and frontend.
  - Map ports 8000 and 3000 for backend and frontend.
  - Set environment variables for backend and frontend.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gaetangr/scytalio/pull/6?shareId=09a73cc9-43f1-4b88-88d0-dab8ab501f9d).