### PR TITLE
Add Docker and nginx configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN apt-get update && apt-get install -y nginx
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,32 @@ The goal of Scytalio is to facilitate secure sharing of sensitive content—such
 
 2. The frontend will be available at `http://localhost:8080`.
 
+## Running the Application with Docker and Nginx
+
+1. Ensure Docker and Docker Compose are installed on your machine.
+
+2. Clone the repository:
+
+    ```sh
+    git clone https://github.com/gaetangr/scytalio.git
+    cd scytalio
+    ```
+
+3. Create a `.env` file in the root directory and add the following lines:
+
+    ```sh
+    echo "DATABASE_URL=sqlite:///./scytalio.db" > .env
+    echo "VITE_API_BASE_URL=http://localhost:8000" >> .env
+    ```
+
+4. Build and start the services using Docker Compose:
+
+    ```sh
+    docker-compose up --build
+    ```
+
+5. The frontend will be available at `http://localhost`, and the API will be available at `http://localhost/api`.
+
 ## Running Tests
 
 ### Backend
@@ -136,3 +162,15 @@ Scytalio is an open-source project and we welcome contributions! To get started,
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](http://_vscodecontentref_/1) file for details.
+
+## Self-Hosting
+
+Scytalio can be self-hosted, allowing you to run your own instance of the application. This is useful if you want to have full control over your data and the environment in which the application runs.
+
+### Features
+
+- **Self-Hosting**: Run your own instance of Scytalio on your server.
+- **Network Sharing**: Share encrypted messages within your network securely.
+- **Customizable**: Modify the source code to fit your specific needs.
+
+To get started with self-hosting, follow the instructions in the "Running the Application with Docker and Nginx" section above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - "8000:8000"
     environment:
       - DATABASE_URL=sqlite:///./scytalio.db
+    volumes:
+      - backend_data:/app/data
 
   frontend:
     build:
@@ -16,4 +18,19 @@ services:
       - "5173:5173"
     environment:
       - VITE_API_BASE_URL=http://localhost:8000
+    volumes:
+      - frontend_node_modules:/frontend/node_modules
 
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - backend
+      - frontend
+
+volumes:
+  backend_data:
+  frontend_node_modules:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,10 @@ RUN npm install --no-cache
 
 COPY . .
 
+RUN apt-get update && apt-get install -y nginx
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
 EXPOSE 5173
 
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,56 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    upstream backend {
+        server backend:8000;
+    }
+
+    upstream frontend {
+        server frontend:5173;
+    }
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        location /api/ {
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
Add Docker and Nginx support for self-hosting Scytalio.

* **docker-compose.yml**
  - Add volumes for backend and frontend services to persist data and node_modules.
  - Add nginx service to serve frontend and backend.

* **Dockerfile**
  - Add steps to install nginx and copy nginx.conf to the container.

* **frontend/Dockerfile**
  - Add steps to install nginx and copy nginx.conf to the container.

* **nginx.conf**
  - Add configuration to serve frontend and backend.

* **README.md**
  - Add instructions to run the application with Docker and Nginx.
  - Add a section indicating that Scytalio can be self-hosted.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gaetangr/scytalio/pull/13?shareId=750d510f-a382-489a-8421-4d3997b59378).