### PR TITLE
Add Pydantic settings to project

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,13 +1,11 @@
 from sqlmodel import SQLModel, create_engine, Session
-import os
-from dotenv import load_dotenv
+from settings import Settings
 from typing import Generator
 from models import EncryptedContent
 
-load_dotenv()
+settings = Settings()
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./scytalio.db")
-engine = create_engine(DATABASE_URL, echo=True)
+engine = create_engine(settings.DATABASE_URL, echo=settings.DEBUG)
 
 
 def create_db_and_tables() -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 
+settings = Settings()
 
 def create_app() -> FastAPI:
     @asynccontextmanager
@@ -31,10 +32,10 @@ def create_app() -> FastAPI:
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=Settings.ALLOWED_ORIGINS,
-        allow_credentials=Settings.ALLOW_CREDENTIALS,
-        allow_methods=Settings.ALLOWED_METHODS,
-        allow_headers=Settings.ALLOWED_HEADERS,
+        allow_origins=settings.ALLOWED_ORIGINS,
+        allow_credentials=settings.ALLOW_CREDENTIALS,
+        allow_methods=settings.ALLOWED_METHODS,
+        allow_headers=settings.ALLOWED_HEADERS,
     )
 
     app.include_router(encrypt.router)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -12,3 +12,5 @@ pytest-asyncio
 slowapi
 ruff
 alembic
+pydantic
+pydantic-settings

--- a/app/routes/decrypt.py
+++ b/app/routes/decrypt.py
@@ -20,7 +20,7 @@ router = APIRouter()
 # The request argument must be explicitly passed to
 # the endpoint for the rate limiter to work.
 @router.get("/decrypt/{message_id}", response_model=EncryptedContent)
-@limiter.limit(f"{Settings.RATE_LIMITING_DEFAULT}/minute")
+@limiter.limit(f"{Settings().RATE_LIMITING_DEFAULT}/minute")
 async def get_encrypted_message(
     request: Request, message_id: str, session: Annotated[Session, Depends(get_session)]
 ) -> EncryptedContent:

--- a/app/routes/encrypt.py
+++ b/app/routes/encrypt.py
@@ -22,7 +22,7 @@ limiter = Limiter(key_func=get_remote_address)
     response_model=EncryptedContent,
     status_code=status.HTTP_201_CREATED,
 )
-@limiter.limit(f"{Settings.RATE_LIMITING_DEFAULT}/minute")
+@limiter.limit(f"{Settings().RATE_LIMITING_DEFAULT}/minute")
 async def encrypt_message(
     request: Request,
     content: EncryptedContent,

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,17 +1,18 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 
 class Settings(BaseSettings):
     """Application settings and constants."""
 
-    DEBUG: bool = False
-    ALLOWED_ORIGINS: list[str] = ["*"]
-    ALLOWED_METHODS: list[str] = ["*"]
-    ALLOWED_HEADERS: list[str] = ["*"]
-    ALLOW_CREDENTIALS: bool = True
-    RATE_LIMITING_DEFAULT: int = 20
-    DATABASE_URL: str = "sqlite:///database.db"
-    SQLITE_CONNECT_ARGS: dict = {"check_same_thread": False}
+    DEBUG: bool = Field(default=False, env="DEBUG")
+    ALLOWED_ORIGINS: list[str] = Field(default=["*"], env="ALLOWED_ORIGINS")
+    ALLOWED_METHODS: list[str] = Field(default=["*"], env="ALLOWED_METHODS")
+    ALLOWED_HEADERS: list[str] = Field(default=["*"], env="ALLOWED_HEADERS")
+    ALLOW_CREDENTIALS: bool = Field(default=True, env="ALLOW_CREDENTIALS")
+    RATE_LIMITING_DEFAULT: int = Field(default=20, env="RATE_LIMITING_DEFAULT")
+    DATABASE_URL: str = Field(default="sqlite:///database.db", env="DATABASE_URL")
+    SQLITE_CONNECT_ARGS: dict = Field(default={"check_same_thread": False}, env="SQLITE_CONNECT_ARGS")
 
     class Config:
         env_file = ".env"

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,18 +1,17 @@
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///database.db")
-SQLITE_CONNECT_ARGS = {"check_same_thread": False}
+from pydantic import BaseSettings
 
 
-class Settings:
+class Settings(BaseSettings):
     """Application settings and constants."""
 
-    DEBUG: bool = os.getenv("DEBUG", False)
+    DEBUG: bool = False
     ALLOWED_ORIGINS: list[str] = ["*"]
     ALLOWED_METHODS: list[str] = ["*"]
     ALLOWED_HEADERS: list[str] = ["*"]
     ALLOW_CREDENTIALS: bool = True
-    RATE_LIMITING_DEFAULT: int = os.getenv("", 20)
+    RATE_LIMITING_DEFAULT: int = 20
+    DATABASE_URL: str = "sqlite:///database.db"
+    SQLITE_CONNECT_ARGS: dict = {"check_same_thread": False}
+
+    class Config:
+        env_file = ".env"

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,18 +1,17 @@
-from pydantic_settings import BaseSettings
-from pydantic import Field
+from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
     """Application settings and constants."""
 
-    DEBUG: bool = Field(default=False, env="DEBUG")
-    ALLOWED_ORIGINS: list[str] = Field(default=["*"], env="ALLOWED_ORIGINS")
-    ALLOWED_METHODS: list[str] = Field(default=["*"], env="ALLOWED_METHODS")
-    ALLOWED_HEADERS: list[str] = Field(default=["*"], env="ALLOWED_HEADERS")
-    ALLOW_CREDENTIALS: bool = Field(default=True, env="ALLOW_CREDENTIALS")
-    RATE_LIMITING_DEFAULT: int = Field(default=20, env="RATE_LIMITING_DEFAULT")
-    DATABASE_URL: str = Field(default="sqlite:///database.db", env="DATABASE_URL")
-    SQLITE_CONNECT_ARGS: dict = Field(default={"check_same_thread": False}, env="SQLITE_CONNECT_ARGS")
+    DEBUG: bool = False
+    ALLOWED_ORIGINS: list[str] = ["*"]
+    ALLOWED_METHODS: list[str] = ["*"]
+    ALLOWED_HEADERS: list[str] = ["*"]
+    ALLOW_CREDENTIALS: bool = True
+    RATE_LIMITING_DEFAULT: int = 20
+    DATABASE_URL: str = "sqlite:///database.db"
+    SQLITE_CONNECT_ARGS: dict = {"check_same_thread": False}
 
     class Config:
         env_file = ".env"

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -6,6 +6,7 @@ from models import EncryptedContent
 
 from app.database import engine, get_session
 from app.main import app
+from app.settings import Settings
 
 # This conftest.py file is used by pytest to define shared fixtures
 # across multiple test files. Fixtures allow you to set up states


### PR DESCRIPTION
Update project to use Pydantic for settings management.

* **app/settings.py**: Replace the current settings implementation with Pydantic BaseSettings. Define settings as Pydantic fields and add a method to load settings from environment variables.
* **app/main.py**: Import the new Pydantic settings and update the CORS middleware configuration to use the new settings.
* **app/routes/decrypt.py**: Import the new Pydantic settings and update the rate limiting configuration to use the new settings.
* **app/routes/encrypt.py**: Import the new Pydantic settings and update the rate limiting configuration to use the new settings.
* **app/database.py**: Import the new Pydantic settings and update the database configuration to use the new settings.
* **app/tests/conftest.py**: Import the new Pydantic settings.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gaetangr/scytalio/pull/23?shareId=ada03a7f-5ef0-4018-8721-1c7d6487433b).